### PR TITLE
Add prototype Splunk app generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-This will be the readme file.
+# Splunk App Builder
+
+This project provides a lightweight prototype for generating Splunk apps using a conversational web interface. The server is implemented with Node's built-in modules so no external dependencies are required.
+
+## Features
+
+- Chat-like interface for entering basic app information
+- Generates a simple app skeleton in the `generated` folder
+- Download the generated app as a zip archive
+
+This implementation uses placeholders for the actual Splunk UCC generator and CI/CD pipeline. It is intended only as a starting point for a more full‑featured solution.
+
+## Running
+
+```bash
+node server.js
+```
+
+Visit `http://localhost:3000` in your browser.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "splunk-app-builder",
+  "version": "1.0.0",
+  "description": "Prototype Splunk app generator",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,35 @@
+const messages = document.getElementById('messages');
+const input = document.getElementById('input');
+const sendBtn = document.getElementById('send');
+const downloadDiv = document.getElementById('download');
+const downloadLink = document.getElementById('downloadLink');
+
+let appName = '';
+
+sendBtn.addEventListener('click', async () => {
+  const text = input.value.trim();
+  if (!text) return;
+  addMessage('user', text);
+  input.value = '';
+  const res = await fetch('/api/generate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ appName: text })
+  });
+  const data = await res.json();
+  if (data.status === 'ok') {
+    appName = data.app;
+    addMessage('system', `App ${appName} generated.`);
+    downloadLink.href = `/api/download?app=${appName}`;
+    downloadDiv.classList.remove('hidden');
+  } else {
+    addMessage('system', 'Error generating app');
+  }
+});
+
+function addMessage(sender, text) {
+  const div = document.createElement('div');
+  div.textContent = `${sender}: ${text}`;
+  messages.appendChild(div);
+  messages.scrollTop = messages.scrollHeight;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Splunk App Builder</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Splunk App Builder</h1>
+    <div id="chat">
+      <div class="messages" id="messages"></div>
+      <input id="input" placeholder="Describe your app requirements"/>
+      <button id="send">Send</button>
+    </div>
+    <div id="download" class="hidden">
+      <p>Your app is ready.</p>
+      <a id="downloadLink" href="#">Download ZIP</a>
+    </div>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,35 @@
+body {
+  font-family: Arial, sans-serif;
+  background: linear-gradient(135deg, rgba(255,255,255,0.1), rgba(255,255,255,0));
+  backdrop-filter: blur(10px);
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+  background-color: #2b2b2b;
+}
+.container {
+  background: rgba(255,255,255,0.15);
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 4px 30px rgba(0,0,0,0.1);
+  width: 400px;
+}
+#chat {
+  display: flex;
+  flex-direction: column;
+}
+.messages {
+  height: 200px;
+  overflow-y: auto;
+  background: rgba(255,255,255,0.05);
+  padding: 10px;
+  margin-bottom: 10px;
+  border-radius: 5px;
+}
+input {
+  padding: 5px;
+  margin-bottom: 10px;
+}
+.hidden { display: none; }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,91 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const PORT = process.env.PORT || 3000;
+const PUBLIC_DIR = path.join(__dirname, 'public');
+const GEN_DIR = path.join(__dirname, 'generated');
+
+function serveStatic(req, res) {
+  const filePath = req.url === '/' ? '/index.html' : req.url;
+  const fullPath = path.join(PUBLIC_DIR, filePath);
+  fs.readFile(fullPath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    const ext = path.extname(fullPath).toLowerCase();
+    const type = {
+      '.html': 'text/html',
+      '.css': 'text/css',
+      '.js': 'application/javascript'
+    }[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': type });
+    res.end(data);
+  });
+}
+
+function handleGenerate(req, res) {
+  let body = '';
+  req.on('data', chunk => body += chunk);
+  req.on('end', () => {
+    try {
+      const data = JSON.parse(body);
+      const appName = (data.appName || 'my_app').replace(/\W+/g, '_');
+      const appDir = path.join(GEN_DIR, appName);
+      fs.mkdirSync(appDir, { recursive: true });
+      fs.writeFileSync(path.join(appDir, 'README.txt'), `Generated Splunk app: ${appName}\n`);
+      fs.writeFileSync(path.join(appDir, 'metadata.json'), JSON.stringify(data, null, 2));
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok', app: appName }));
+    } catch (e) {
+      res.writeHead(500);
+      res.end('Error generating app');
+    }
+  });
+}
+
+function handleDownload(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const app = url.searchParams.get('app');
+  if (!app) {
+    res.writeHead(400);
+    res.end('Missing app parameter');
+    return;
+  }
+  const appDir = path.join(GEN_DIR, app);
+  if (!fs.existsSync(appDir)) {
+    res.writeHead(404);
+    res.end('App not found');
+    return;
+  }
+  const zipPath = path.join(GEN_DIR, `${app}.zip`);
+  try {
+    execSync(`zip -r ${zipPath} ${app}`, { cwd: GEN_DIR });
+    const zipData = fs.readFileSync(zipPath);
+    res.writeHead(200, {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': `attachment; filename="${app}.zip"`
+    });
+    res.end(zipData);
+  } catch (e) {
+    res.writeHead(500);
+    res.end('Error creating archive');
+  }
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/api/generate') {
+    return handleGenerate(req, res);
+  } else if (req.method === 'GET' && req.url.startsWith('/api/download')) {
+    return handleDownload(req, res);
+  } else {
+    return serveStatic(req, res);
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- set up a simple web interface for a Splunk app generator
- implement a minimal Node server with endpoints for generating and downloading app archives
- add basic glassmorphic UI
- document usage in README

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_687a2edd86f8832291eb55f0b312e608