### PR TITLE
Add OpenRouter option for code generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+generated/
+*.zip

--- a/README.md
+++ b/README.md
@@ -1,19 +1,25 @@
 # Splunk App Builder
 
-This project provides a lightweight prototype for generating Splunk apps using a conversational web interface. The server is implemented with Node's built-in modules so no external dependencies are required.
+This project provides a lightweight prototype for generating Splunk apps using a conversational web interface. The server is implemented with Node's built-in modules and uses the official Claude SDK when API keys are supplied.
 
 ## Features
 
-- Chat-like interface for entering basic app information
-- Generates a simple app skeleton in the `generated` folder
+- Conversational interface that collects app name, author, version, description and modular input details
+- Generates a simple Splunk UCC-style skeleton in the `generated` folder
+- Optional Claude-based code generation when either `ANTHROPIC_API_KEY` or `OPENROUTER_API_KEY` is set
+- Attempts to bootstrap a Splunk UCC add-on using `ucc-gen` if available
 - Download the generated app as a zip archive
 
 This implementation uses placeholders for the actual Splunk UCC generator and CI/CD pipeline. It is intended only as a starting point for a more full‑featured solution.
+Running with one of the API keys will call Claude via the Anthropic SDK or OpenRouter to produce a sample `addon.py` file.
 
 ## Running
 
 ```bash
 node server.js
 ```
+
+Set `ANTHROPIC_API_KEY` or `OPENROUTER_API_KEY` to enable automatic code generation.
+Run `npm test` to execute a basic sanity check of the Claude helper.
 
 Visit `http://localhost:3000` in your browser.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project provides a lightweight prototype for generating Splunk apps using a
 - Optional Claude-based code generation when either `ANTHROPIC_API_KEY` or `OPENROUTER_API_KEY` is set
 - Attempts to bootstrap a Splunk UCC add-on using `ucc-gen` if available
 - Download the generated app as a zip archive
+- Optionally push the generated code to a GitHub repository
 
 This implementation uses placeholders for the actual Splunk UCC generator and CI/CD pipeline. It is intended only as a starting point for a more full‑featured solution.
 Running with one of the API keys will call Claude via the Anthropic SDK or OpenRouter to produce a sample `addon.py` file.
@@ -20,6 +21,7 @@ node server.js
 ```
 
 Set `ANTHROPIC_API_KEY` or `OPENROUTER_API_KEY` to enable automatic code generation.
-Run `npm test` to execute a basic sanity check of the Claude helper.
+Provide `GITHUB_TOKEN` and repository details when prompted to push the generated app to GitHub. The app will initialize a git repository under `generated/<appName>` and attempt to push the code to the specified remote.
+Run `npm test` after installing dependencies with `npm install` to verify basic functionality.
 
 Visit `http://localhost:3000` in your browser.

--- a/claude.js
+++ b/claude.js
@@ -1,0 +1,80 @@
+const https = require('https');
+const Anthropic = require('@anthropic-ai/sdk');
+
+/**
+ * Call the Anthropic completion API.
+ * @param {string} prompt
+ * @param {string} apiKey
+ */
+async function callAnthropic(prompt, apiKey) {
+  const client = new Anthropic({ apiKey });
+  const response = await client.messages.create({
+    model: 'claude-3-opus-20240229',
+    max_tokens: 4096,
+    temperature: 0,
+    messages: [{ role: 'user', content: prompt }]
+  });
+  return response.content?.[0]?.text || '';
+}
+
+/**
+ * Call the OpenRouter API using the Anthropic model.
+ * @param {string} prompt
+ * @param {string} apiKey
+ */
+function callOpenRouter(prompt, apiKey) {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify({
+      model: 'anthropic/claude-3-opus',
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 4096,
+      temperature: 0
+    });
+
+    const options = {
+      hostname: 'openrouter.ai',
+      path: '/api/v1/chat/completions',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Length': Buffer.byteLength(data)
+      }
+    };
+
+    const req = https.request(options, res => {
+      let body = '';
+      res.on('data', chunk => body += chunk);
+      res.on('end', () => {
+        try {
+          const parsed = JSON.parse(body);
+          const text = parsed.choices && parsed.choices[0] && parsed.choices[0].message && parsed.choices[0].message.content;
+          resolve(text || '');
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+/**
+ * Generate code using either Anthropic or OpenRouter depending on
+ * available API keys.
+ * @param {string} prompt - Prompt describing the code to generate
+ * @returns {Promise<string>} - Generated code or empty string if no API key
+ */
+function generateCode(prompt) {
+  if (process.env.OPENROUTER_API_KEY) {
+    return callOpenRouter(prompt, process.env.OPENROUTER_API_KEY);
+  } else if (process.env.ANTHROPIC_API_KEY) {
+    return callAnthropic(prompt, process.env.ANTHROPIC_API_KEY);
+  }
+  return Promise.resolve('');
+}
+
+module.exports = { generateCode };

--- a/github.js
+++ b/github.js
@@ -1,0 +1,21 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function pushToGitHub(appDir, repo, token) {
+  try {
+    execSync('git init', { cwd: appDir });
+    execSync('git add .', { cwd: appDir });
+    execSync('git commit -m "Initial commit"', { cwd: appDir });
+    const remote = `https://${token}@github.com/${repo}.git`;
+    execSync(`git push ${remote} master --force`, { cwd: appDir, stdio: 'ignore' });
+    return true;
+  } catch (e) {
+    try {
+      fs.writeFileSync(path.join(appDir, 'github_error.log'), String(e));
+    } catch {}
+    return false;
+  }
+}
+
+module.exports = { pushToGitHub };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "splunk-app-builder",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "splunk-app-builder",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.56.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.56.0.tgz",
+      "integrity": "sha512-SLCB8M8+VMg1cpCucnA1XWHGWqVSZtIWzmOdDOEu3eTFZMB+A0sGZ1ESO5MHDnqrNTXz3safMrWx9x4rMZSOqA==",
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,10 +4,14 @@
   "description": "Prototype Splunk app generator",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node test.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.56.0"
+  }
 }

--- a/public/app.js
+++ b/public/app.js
@@ -4,23 +4,48 @@ const sendBtn = document.getElementById('send');
 const downloadDiv = document.getElementById('download');
 const downloadLink = document.getElementById('downloadLink');
 
-let appName = '';
+const questions = [
+  { key: 'appName', text: 'What is the app name?' },
+  { key: 'author', text: 'Who is the author?' },
+  { key: 'version', text: 'Initial version number?', default: '1.0.0' },
+  { key: 'description', text: 'Provide a short description of the app.' },
+  { key: 'inputType', text: 'Describe the modular input this add-on should implement.' }
+];
+
+let step = 0;
+const answers = {};
+let currentApp = '';
+
+function askNext() {
+  if (step < questions.length) {
+    addMessage('system', questions[step].text);
+  }
+}
 
 sendBtn.addEventListener('click', async () => {
   const text = input.value.trim();
   if (!text) return;
   addMessage('user', text);
+  const q = questions[step];
+  answers[q.key] = text || q.default || '';
   input.value = '';
+  step++;
+
+  if (step < questions.length) {
+    askNext();
+    return;
+  }
+
   const res = await fetch('/api/generate', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ appName: text })
+    body: JSON.stringify(answers)
   });
   const data = await res.json();
   if (data.status === 'ok') {
-    appName = data.app;
-    addMessage('system', `App ${appName} generated.`);
-    downloadLink.href = `/api/download?app=${appName}`;
+    currentApp = data.app;
+    addMessage('system', `App ${currentApp} generated.`);
+    downloadLink.href = `/api/download?app=${currentApp}`;
     downloadDiv.classList.remove('hidden');
   } else {
     addMessage('system', 'Error generating app');
@@ -33,3 +58,6 @@ function addMessage(sender, text) {
   messages.appendChild(div);
   messages.scrollTop = messages.scrollHeight;
 }
+
+// kick off the conversation
+askNext();

--- a/public/app.js
+++ b/public/app.js
@@ -9,7 +9,9 @@ const questions = [
   { key: 'author', text: 'Who is the author?' },
   { key: 'version', text: 'Initial version number?', default: '1.0.0' },
   { key: 'description', text: 'Provide a short description of the app.' },
-  { key: 'inputType', text: 'Describe the modular input this add-on should implement.' }
+  { key: 'inputType', text: 'Describe the modular input this add-on should implement.' },
+  { key: 'githubRepo', text: 'GitHub repo to push to (owner/repo) or leave blank.' },
+  { key: 'githubToken', text: 'GitHub token (leave blank to skip push).' }
 ];
 
 let step = 0;
@@ -47,6 +49,19 @@ sendBtn.addEventListener('click', async () => {
     addMessage('system', `App ${currentApp} generated.`);
     downloadLink.href = `/api/download?app=${currentApp}`;
     downloadDiv.classList.remove('hidden');
+    if (answers.githubRepo && answers.githubToken) {
+      addMessage('system', 'Pushing to GitHub...');
+      const gh = await fetch('/api/github', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ app: currentApp, repo: answers.githubRepo, token: answers.githubToken })
+      });
+      if (gh.ok) {
+        addMessage('system', 'GitHub push complete');
+      } else {
+        addMessage('system', 'GitHub push failed');
+      }
+    }
   } else {
     addMessage('system', 'Error generating app');
   }

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     <h1>Splunk App Builder</h1>
     <div id="chat">
       <div class="messages" id="messages"></div>
-      <input id="input" placeholder="Describe your app requirements"/>
+      <input id="input" placeholder="Type your answer here"/>
       <button id="send">Send</button>
     </div>
     <div id="download" class="hidden">

--- a/server.js
+++ b/server.js
@@ -2,6 +2,28 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
+const { generateCode } = require('./claude');
+
+function ensureUccGen() {
+  try {
+    execSync('which ucc-gen', { stdio: 'ignore' });
+  } catch {
+    try {
+      execSync('pip install --quiet splunk-add-on-ucc-framework');
+    } catch (e) {
+      console.warn('Failed to install ucc-gen:', e.message);
+    }
+  }
+}
+
+function runUccGen(dir, meta) {
+  ensureUccGen();
+  try {
+    execSync(`ucc-gen --output ${dir} --addon-name ${meta.appName}`, { stdio: 'inherit' });
+  } catch (e) {
+    fs.writeFileSync(path.join(dir, 'ucc_error.log'), String(e));
+  }
+}
 
 const PORT = process.env.PORT || 3000;
 const PUBLIC_DIR = path.join(__dirname, 'public');
@@ -27,19 +49,38 @@ function serveStatic(req, res) {
   });
 }
 
-function handleGenerate(req, res) {
+async function handleGenerate(req, res) {
   let body = '';
   req.on('data', chunk => body += chunk);
-  req.on('end', () => {
+  req.on('end', async () => {
     try {
       const data = JSON.parse(body);
-      const appName = (data.appName || 'my_app').replace(/\W+/g, '_');
-      const appDir = path.join(GEN_DIR, appName);
+      const meta = {
+        appName: (data.appName || 'my_app').replace(/\W+/g, '_'),
+        author: data.author || '',
+        version: data.version || '1.0.0',
+        description: data.description || '',
+        inputType: data.inputType || ''
+      };
+
+      const appDir = path.join(GEN_DIR, meta.appName);
       fs.mkdirSync(appDir, { recursive: true });
-      fs.writeFileSync(path.join(appDir, 'README.txt'), `Generated Splunk app: ${appName}\n`);
-      fs.writeFileSync(path.join(appDir, 'metadata.json'), JSON.stringify(data, null, 2));
+      fs.writeFileSync(path.join(appDir, 'metadata.json'), JSON.stringify(meta, null, 2));
+      fs.writeFileSync(path.join(appDir, 'README.txt'), `Generated Splunk app: ${meta.appName}\n${meta.description}\n`);
+      runUccGen(appDir, meta);
+
+      if (process.env.ANTHROPIC_API_KEY || process.env.OPENROUTER_API_KEY) {
+        try {
+          const prompt = `You are a senior Splunk developer. Build a minimal Splunk Add-on using the UCC Framework.\nName: ${meta.appName}\nAuthor: ${meta.author}\nVersion: ${meta.version}\nDescription: ${meta.description}\nInput: ${meta.inputType}\nReturn only the contents of addon.py implementing a placeholder modular input.`;
+          const code = await generateCode(prompt);
+          fs.writeFileSync(path.join(appDir, 'addon.py'), code);
+        } catch (e) {
+          fs.writeFileSync(path.join(appDir, 'claude_error.log'), String(e));
+        }
+      }
+
       res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ status: 'ok', app: appName }));
+      res.end(JSON.stringify({ status: 'ok', app: meta.appName }));
     } catch (e) {
       res.writeHead(500);
       res.end('Error generating app');

--- a/test.js
+++ b/test.js
@@ -1,5 +1,8 @@
 const assert = require('assert');
 const { generateCode } = require('./claude');
+const { pushToGitHub } = require('./github');
+const fs = require('fs');
+const path = require('path');
 
 (async () => {
   const saveOpen = process.env.OPENROUTER_API_KEY;
@@ -10,5 +13,9 @@ const { generateCode } = require('./claude');
   assert.strictEqual(res, '');
   if (saveOpen) process.env.OPENROUTER_API_KEY = saveOpen;
   if (saveAnthro) process.env.ANTHROPIC_API_KEY = saveAnthro;
+  const tmp = fs.mkdtempSync(path.join(__dirname, 'tmp'));
+  const ok = pushToGitHub(tmp, 'invalid/repo', 'token');
+  assert.strictEqual(ok, false);
+  fs.rmSync(tmp, { recursive: true, force: true });
   console.log('Tests passed');
 })();

--- a/test.js
+++ b/test.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const { generateCode } = require('./claude');
+
+(async () => {
+  const saveOpen = process.env.OPENROUTER_API_KEY;
+  const saveAnthro = process.env.ANTHROPIC_API_KEY;
+  delete process.env.OPENROUTER_API_KEY;
+  delete process.env.ANTHROPIC_API_KEY;
+  const res = await generateCode('test');
+  assert.strictEqual(res, '');
+  if (saveOpen) process.env.OPENROUTER_API_KEY = saveOpen;
+  if (saveAnthro) process.env.ANTHROPIC_API_KEY = saveAnthro;
+  console.log('Tests passed');
+})();


### PR DESCRIPTION
## Summary
- support OpenRouter or Anthropic API keys for code generation
- generate code via OpenRouter when OPENROUTER_API_KEY is present
- document new environment variable in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687a34350ba48322b1eb1316b257202a